### PR TITLE
Typescript definition file and benchmark test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,6 @@ typings/
 # next.js build output
 .next
 # project output
-out/
+out/*
 .DS_Store
 coverage/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ parser.parse(data);
 parser.spit(); // gets parsed data as array of {filename, contents}
 ```
 
-### `Parser.prototype.rerwite()
+### `Parser.prototype.rerwite()`
 
 Rewrites all links in the given mhtml file to refer to the other files and passes them through the parser's `rewriteFn` (filenamify by default).
 

--- a/src/benchmark/benchmark.js
+++ b/src/benchmark/benchmark.js
@@ -1,8 +1,23 @@
+const { mkdirSync } = require('fs');
+const { resolve } = require('path');
 const co = require('bluebird').coroutine;
 const Processor = require('../processor');
 
+/**
+ * Should create out dir for all the out files.
+ */
+try {
+  mkdirSync(resolve(__dirname, '../../out'));
+} catch (err) {
+  if (err.code !== 'EEXIST') {
+    // eslint-disable-next-line no-console
+    console.error(`Unable to perform benchmark because of error ${err.message}`);
+    process.exit(1);
+  }
+}
+
 /* eslint-disable */
-const markP30 = co(function * markP30(fn, name, file) {
+const markP30 = co(function* markP30(fn, name, file) {
   global.gc();
   const start = Date.now();
   yield Promise.all(Array(30).fill().map(() => fn(file)));
@@ -13,7 +28,7 @@ const markP30 = co(function * markP30(fn, name, file) {
     ` Average time: ${(Date.now() - start) / 30}`);
 });
 
-const mark = co(function *(fn, name, file, iterations = 100) {
+const mark = co(function* (fn, name, file, iterations = 100) {
   global.gc();
   const start = Date.now();
   for (let i = 0; i < iterations; i++) {
@@ -27,8 +42,8 @@ const mark = co(function *(fn, name, file, iterations = 100) {
 });
 
 
-const bench = co(function *(name, parser) {
-  console.log(name);  
+const bench = co(function* (name, parser) {
+  console.log(name);
   yield parser("Example.com", "./demos/example.com.mhtml", 1000)
   yield parser("github", "./demos/github.node.mhtml", 100);
   yield parser("github large", "./demos/github.node.biggest.mhtml", 10);
@@ -41,7 +56,7 @@ const bench = co(function *(name, parser) {
 });
 
 /* eslint-disable */
-co(function *() {
+co(function* () {
   const newParser = mark.bind(null, Processor.convert);
   const newParserParallel10 = markP30.bind(null, Processor.convert);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,18 +1,18 @@
 declare module 'fast-mhtml' {
-  type ParserConfig = {
-    rewriteFn: (url: String) => String;
-    maxFileSize: Number
-  };
-  type FileResult = {
+  interface IParserConfig {
+    rewriteFn?: (url: string) => string;
+    maxFileSize?: number
+  }
+  interface IFileResult {
     contents: Buffer | string;
     type: string;
     filename: string;
-  };
+  }
   export class Parser {
-    constructor(config: ParserConfig);
-    parse(contents: Buffer | String);
+    constructor(config?: IParserConfig);
+    parse(contents: Buffer | string);
     rewrite();
-    spit(): FileResult[];
+    spit(): IFileResult[];
   }
   export class Converter {
     static serve();


### PR DESCRIPTION
### I am proposing this change because:

- I believe that it is better to use `interface` instead of `type` for interfaces
- The parser constructor params are optional
- changed `String` to `string` for for `Number`
- benchmark test couldn't run because no out dir so it'll create it 

Checklist:
 - [X] tests were added for new features _No new features_
 - [x] tests and lint pass
 - [X] benchmark ran
