### PR TITLE
fix: decode to end of input buffer

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -35,10 +35,9 @@ function convertQuotedPrintable(body) {
   const len = body.length;
   const decoded = Buffer.alloc(len); // at most this big
   let j = 0;
-  const runTo = len - 3;
-  for (let i = 0; i < runTo; i++) {
-    while (i < runTo && (decoded[j++] = body[i++]) !== EQUALS);
-    if (i >= runTo) break;
+  for (let i = 0; i < len; i++) {
+    while (i < len && (decoded[j++] = body[i++]) !== EQUALS);
+    if (i >= len) break;
     // We are dealing with a '=xx' sequence.
     const upper = body[i];
     const lower = body[++i];
@@ -67,9 +66,6 @@ function convertQuotedPrintable(body) {
     }
     const shifted = upperTranslated << 4;
     decoded[j - 1] = shifted | lowerTranslated;
-  }
-  for (let i = runTo; i < len; i++) {
-    decoded[j++] = body[i];
   }
   return decoded.slice(0, j);
 }

--- a/src/decoder.test.js
+++ b/src/decoder.test.js
@@ -56,6 +56,13 @@ describe('decoding', () => {
     expect(decoder('binary', Buffer.from('Hello')).toString()).to.equal('Hello');
   });
 
+  it('decodes quoted printable at end of input', () => {
+    expect(
+      decoder('quoted-printable',
+        Buffer.from('Hello World =3E')).toString()
+    ).to.equal('Hello World >');
+  });
+
   it('throws on unknown encodings', () => {
     expect(() => decoder('kaka', Buffer.from('hello'))).to.throw();
   });


### PR DESCRIPTION
### I am proposing this change because:

It seems like the decoder early exits, and won't actually decode any quoted printable encoded characters at the end of the input buffer. An effect of this is the failure to decode SVGs, which (at least in how Chrome includes them as part of MHTML, with an `=0A` as the last characters). If you look at the demos including SVGs (e.g. `mdn.mhtml`), SVGs fail to render as they end up with a partially decoded escape sequence.

<details>
  <summary>Benchmark on master</summary>

```
npm run benchmark

> fast-mhtml@1.1.8 benchmark
> node --expose-gc src/benchmark/benchmark.js

Parser Serial
Converted Example.com 1000 times. Memory(17.08087158203125) Average time: 0.335
Converted github 100 times. Memory(29.9013671875) Average time: 12.7
Converted github large 10 times. Memory(12.516754150390625) Average time: 63.6
Converted github unhandled rejection 10 times. Memory(17.88842010498047) Average time: 37.9
Converted mdn 20 times. Memory(22.71173858642578) Average time: 8
Converted wikipedia 20 times. Memory(20.58464813232422) Average time: 7.1
Converted hn 20 times. Memory(13.098945617675781) Average time: 1.2
Converted aliexpress 10 times. Memory(18.262954711914062) Average time: 213.5
Converted stackoverflow 10 times. Memory(28.987258911132812) Average time: 29.6
Parser Parallel 30
Converted Example.com in p=30. Memory(11.286109924316406)  Average time: 0.26666666666666666
Converted github in p=30. Memory(58.45661926269531)  Average time: 11.733333333333333
Converted github large in p=30. Memory(58.45878601074219)  Average time: 53.03333333333333
Converted github unhandled rejection in p=30. Memory(60.31971740722656)  Average time: 32.833333333333336
Converted mdn in p=30. Memory(30.600082397460938)  Average time: 7.066666666666666
Converted wikipedia in p=30. Memory(17.563674926757812)  Average time: 6
Converted hn in p=30. Memory(14.317787170410156)  Average time: 1
Converted aliexpress in p=30. Memory(114.23297119140625)  Average time: 193.56666666666666
Converted stackoverflow in p=30. Memory(63.90680694580078)  Average time: 27.4

```
</details>
<details>
  <summary>Benchmark with the change</summary>

```
npm run benchmark

> fast-mhtml@1.1.8 benchmark
> node --expose-gc src/benchmark/benchmark.js

Parser Serial
Converted Example.com 1000 times. Memory(16.998092651367188) Average time: 0.318
Converted github 100 times. Memory(20.9410400390625) Average time: 11.83
Converted github large 10 times. Memory(12.311691284179688) Average time: 62.7
Converted github unhandled rejection 10 times. Memory(17.889869689941406) Average time: 37
Converted mdn 20 times. Memory(28.976295471191406) Average time: 7.8
Converted wikipedia 20 times. Memory(17.522705078125) Average time: 7.05
Converted hn 20 times. Memory(12.946510314941406) Average time: 1.3
Converted aliexpress 10 times. Memory(14.266868591308594) Average time: 223.1
Converted stackoverflow 10 times. Memory(28.886497497558594) Average time: 27.9
Parser Parallel 30
Converted Example.com in p=30. Memory(11.119819641113281)  Average time: 0.13333333333333333
Converted github in p=30. Memory(65.85737609863281)  Average time: 11.166666666666666
Converted github large in p=30. Memory(70.75143432617188)  Average time: 51.266666666666666
Converted github unhandled rejection in p=30. Memory(67.74114990234375)  Average time: 32.333333333333336
Converted mdn in p=30. Memory(31.58478546142578)  Average time: 6.6
Converted wikipedia in p=30. Memory(17.58000946044922)  Average time: 6.1
Converted hn in p=30. Memory(14.057991027832031)  Average time: 0.9
Converted aliexpress in p=30. Memory(36.9388427734375)  Average time: 195.8
Converted stackoverflow in p=30. Memory(67.06204986572266)  Average time: 24.866666666666667
```
</details>

Checklist:
 - [x] tests were added for new features
 - [x] tests and lint pass
 - [x] benchmark ran
